### PR TITLE
Wrong version of current federal being used

### DIFF
--- a/pshtt_csv2mongo.py
+++ b/pshtt_csv2mongo.py
@@ -14,7 +14,7 @@ REWRITES_FILE = INCLUDE_DATA_DIR + 'rewrites.csv'
 NON_CYHY_STAKEHOLDERS_FILE = INCLUDE_DATA_DIR + 'noncyhy.csv'
 AGENCIES_FILE = INCLUDE_DATA_DIR + 'agencies.csv'
 
-CURRENT_FEDERAL_FILE = SHARED_DATA_DIR + 'artifacts/current-federal-original.csv'
+CURRENT_FEDERAL_FILE = SHARED_DATA_DIR + 'artifacts/current-federal_modified.csv'
 UNIQUE_AGENCIES_FILE = SHARED_DATA_DIR + 'artifacts/unique-agencies.csv'
 CLEAN_CURRENT_FEDERAL_FILE = SHARED_DATA_DIR + 'artifacts/clean-current-federal.csv'
 

--- a/save_to_db.sh
+++ b/save_to_db.sh
@@ -2,14 +2,6 @@
 
 SHARED_DIR='/home/saver/shared'
 
-# We need a copy of current-federal so we download a copy of just
-# that.  We need the raw file, and domain-scan/gather modifies the
-# fields in the CSV, so we'll use wget here.
-mkdir -p $SHARED_DIR/artifacts/
-wget https://raw.githubusercontent.com/GSA/data/master/dotgov-domains/current-federal.csv \
-     -O current-federal.csv
-mv current-federal.csv $SHARED_DIR/artifacts/current-federal-original.csv
-
 echo 'Waiting for scanner'
 while [ "$(redis-cli -h orchestrator_redis_1 get scanning_complete)" != "true" ]
 do

--- a/sslyze_csv2mongo.py
+++ b/sslyze_csv2mongo.py
@@ -15,7 +15,7 @@ REWRITES_FILE = INCLUDE_DATA_DIR + 'rewrites.csv'
 NON_CYHY_STAKEHOLDERS_FILE = INCLUDE_DATA_DIR + 'noncyhy.csv'
 AGENCIES_FILE = INCLUDE_DATA_DIR + 'agencies.csv'
 
-CURRENT_FEDERAL_FILE = SHARED_DATA_DIR + 'artifacts/current-federal-original.csv'
+CURRENT_FEDERAL_FILE = SHARED_DATA_DIR + 'artifacts/current-federal_modified.csv'
 UNIQUE_AGENCIES_FILE = SHARED_DATA_DIR + 'artifacts/unique-agencies.csv'
 CLEAN_CURRENT_FEDERAL_FILE = SHARED_DATA_DIR + 'artifacts/clean-current-federal.csv'
 

--- a/trustymail_csv2mongo.py
+++ b/trustymail_csv2mongo.py
@@ -15,7 +15,7 @@ REWRITES_FILE = INCLUDE_DATA_DIR + 'rewrites.csv'
 NON_CYHY_STAKEHOLDERS_FILE = INCLUDE_DATA_DIR + 'noncyhy.csv'
 AGENCIES_FILE = INCLUDE_DATA_DIR + 'agencies.csv'
 
-CURRENT_FEDERAL_FILE = SHARED_DATA_DIR + 'artifacts/current-federal-original.csv'
+CURRENT_FEDERAL_FILE = SHARED_DATA_DIR + 'artifacts/current-federal_modified.csv'
 UNIQUE_AGENCIES_FILE = SHARED_DATA_DIR + 'artifacts/unique-agencies.csv'
 CLEAN_CURRENT_FEDERAL_FILE = SHARED_DATA_DIR + 'artifacts/clean-current-federal.csv'
 


### PR DESCRIPTION
@Essex09 pointed out that the domains we add to the current federal list in dhs-ncats/gatherer are not appearing in the reports.  I realized that is because we should be using `current-federal_modified.csv` [here](https://github.com/dhs-ncats/saver/blob/develop/pshtt_csv2mongo.py#L118) instead of `current-federal-original.csv`.  In fact, `current-federal-original.csv` is not needed at all.

See also OPS-2327.

I did a full staging run with this change.  The results can be found at `c4b4:/tmp/archive/artifacts_2018-03-18.tar.gz`.  They can be compared with this week's production run, located at `c3b4:/var/cyhy/orchestrator/output/archive/artifacts_2018-03-17.tar.gz `.