### PR TITLE
Change Docker Hub organization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 env:
   global:
-    - IMAGE_NAME=dhsncats/saver
+    - IMAGE_NAME=cisagov/saver
     - DOCKER_USER=jsf9k
     - secure: "KOBnF822WhgariMvzbFLZYozGUCA/Khc9HVc8jGr6l9k0aiA/8udPc62LNRfWeOzDbs7dIRdorrw8DxtMMXwdaO2eo3OfYodkhwKLJSwYPXyeZO2ossYSyojC1I9f67YqkatUPNnGqd/OwRtxUCnHlIqDZ1SLlNKAkzdtj2HLj9pYvNOCA9ow7XQxhvWijuQ+dJehlACrI2eXHwf3XuDsJSzhQzJkyFAtgyCZ0EkZiyaz9BCldKWeJwO7PHQX0RMPd9vzm5aPTM6192OH99MP/NB43PcK8W2twA03jbCzW4+F8WV+lfpHqsZLk1XKQz4IkTSFXjB7IMSSoqWE/XcD6/Q4l6uodiaM1yzfod6nE/lDMxY76hKilgM4LvEaI/dMAreqhd8Zmsts1nVYms5fY3/0Zegk2d9IsePaj/Vqe0sartPqqYxDDpCN/NVbCkB+2j71K1DtHHyRez8Etbmpuk8r50sIeYzCc2qAWf+ll9VBa6jb+tw5d37JOjlfh+js5bnYG5jU98ZgZ1+uQD3i427XM4vODqxaQ9ppQwYm7EwiOn4VB+cZcaWsuaB0X/fGfJRNU/w/ovAKasW5ONRfuWlyLuoza6Issy9VvwmA8PdwQ8df4aWM3ZhUMWNL9oWESMq6GbK57uNwl0U0WsrbNcgudJ+cbLjNUZy119Z3jI="
 

--- a/travis_scripts/build_docker_image.sh
+++ b/travis_scripts/build_docker_image.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -o nounset
+set -o errexit
+set -o pipefail
+
 # semver uses a plus character for the build number (if present).
 # This is invalid for a Docker tag, so we replace it with a minus.
 version=$(./bump_version.sh show|sed "s/+/-/")

--- a/travis_scripts/build_docker_image.sh
+++ b/travis_scripts/build_docker_image.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
-version=$(./bump_version.sh show)
-docker build -t ${IMAGE_NAME}:$version .
+# semver uses a plus character for the build number (if present).
+# This is invalid for a Docker tag, so we replace it with a minus.
+version=$(./bump_version.sh show|sed "s/+/-/")
+docker build -t "$IMAGE_NAME":"$version" .

--- a/travis_scripts/deploy_to_docker_hub.sh
+++ b/travis_scripts/deploy_to_docker_hub.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -o nounset
+set -o errexit
+set -o pipefail
+
 echo "$DOCKER_PW" | docker login -u "$DOCKER_USER" --password-stdin
 # semver uses a plus character for the build number (if present).
 # This is invalid for a Docker tag, so we replace it with a minus.

--- a/travis_scripts/deploy_to_docker_hub.sh
+++ b/travis_scripts/deploy_to_docker_hub.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
 echo "$DOCKER_PW" | docker login -u "$DOCKER_USER" --password-stdin
-version=$(./bump_version.sh show)
-docker push "$IMAGE_NAME":$version
+# semver uses a plus character for the build number (if present).
+# This is invalid for a Docker tag, so we replace it with a minus.
+version=$(./bump_version.sh show|sed "s/+/-/")
+docker push "$IMAGE_NAME":"$version"


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

Rename the Docker image so that it belongs to the cisagov organization instead of the dhsncats organization.

Also update some scripts that are used by TravisCI so that they can handle build numbers in the version string.  (Stolen from cisagov/scanner.)

## 💭 Motivation and Context

We are migrating to the cisagov organization.

## 🧪 Testing

The TravisCI checks pass.

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
