### PR TITLE
Adding NSCAI and USIP

### DIFF
--- a/include/agencies.csv
+++ b/include/agencies.csv
@@ -79,6 +79,7 @@ National Indian Gaming Commission,NIGC
 National Labor Relations Board,NLRB
 National Mediation Board,NMB
 National Science Foundation,NSF
+National Security Commission on Artificial Intelligence,NSCAI
 National Transportation Safety Board,NTSB
 Nuclear Regulatory Commission,NRC
 Occupational Safety and Health Review Commission,OSHRC
@@ -105,6 +106,7 @@ United States Access Board,USAB
 United States African Development Foundation,USADF
 United States Agency for Global Media,USAGM
 United States Holocaust Memorial Museum,USHMM
+United States Institute of Peace,USIP
 United States Interagency Council on Homelessness,USICH
 United States International Development Finance Corporation,DFC
 United States International Trade Commission,USITC


### PR DESCRIPTION
Also recently found that NSCAI and USIP are not receiving BOD reports, appears to be because while their long name matches the long name in our DB, they weren't here on this list.

`agencies.csv` maps agency names from https://github.com/cisagov/dotgov-data/blob/main/current-federal.csv to CyHy IDs.  So any agencies in `current-federal.csv` that are also CyHy stakeholders should appear in this file; otherwise, they won't get their BOD 18-01 reports since we have no other way to identify their preferred email address.