### PR TITLE
Upgrade the version of `redis` that is installed to `8.4.2-r0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN addgroup --system --gid ${CISA_UID} ${CISA_GROUP} \
 # longer install times.
 ###
 RUN apk --no-cache add \
-    redis=8.4.1-r0
+    redis=8.4.2-r0
 
 ###
 # Copy in the Python virtual environment created in compile-stage, symlink the


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades the version of the `redis` system package from Alpine Linux to `8.4.2-r0`.

## 💭 Motivation and context ##

The version we previously used (`8.4.1-r0`) is [no longer available from Alpine Linux](https://pkgs.alpinelinux.org/packages?name=redis&branch=v3.23&repo=&arch=&origin=&flagged=&maintainer=).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.