### PR TITLE
Read the Elasticsearch URL from the environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ There are no required environment variables.
 | ---- | ------- | ------- |
 | `AWS_CONFIG_FILE` | The location of the config file containing AWS credentials. | `null` |
 | `AWS_SDK_LOAD_CONFIG` | If set to a truthy value (such as 1), ensures that the config file (and not just any credentials file that is present) is loaded. | `null` |
+| `ELASTICSEARCH_URL` | The base HTTPS URL for a standard AWS-managed Elasticsearch or OpenSearch domain. This must be set when AWS credentials are available, and its region must match the AWS session region. | `null` |
 
 ## Secrets ##
 

--- a/compose.yml
+++ b/compose.yml
@@ -27,6 +27,8 @@ services:
       # Setting this environment variable ensures that the config file
       # (and not just any credentials file that is present) is loaded.
       - AWS_SDK_LOAD_CONFIG=1
+      # This is a placeholder suitable only for local testing.
+      - ELASTICSEARCH_URL=https://search-example.us-east-1.es.amazonaws.com
     image: cisagov/saver
     init: true
     restart: "no"

--- a/src/elasticsearch_config.py
+++ b/src/elasticsearch_config.py
@@ -1,0 +1,63 @@
+"""Elasticsearch configuration helpers."""
+
+# Standard Python Libraries
+from collections.abc import Mapping
+import os
+import re
+from urllib.parse import urlsplit, urlunsplit
+
+ELASTICSEARCH_INDEX = "dmarc_aggregate_reports"
+ELASTICSEARCH_HOST_SUFFIXES = (".es.amazonaws.com", ".es.amazonaws.com.cn")
+
+
+def get_elasticsearch_delete_url(region, environment=None):
+    """Return a validated Elasticsearch delete-by-query URL."""
+    if not isinstance(region, str) or not region:
+        raise RuntimeError("The AWS region must be configured.")
+    if re.fullmatch(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?", region) is None:
+        raise ValueError("The AWS region is invalid.")
+
+    if environment is None:
+        environment = os.environ
+    if not isinstance(environment, Mapping):
+        raise TypeError("environment must be a mapping")
+
+    value = environment.get("ELASTICSEARCH_URL", "").strip()
+    if not value:
+        raise RuntimeError(
+            "The ELASTICSEARCH_URL environment variable must be set when AWS "
+            "credentials are available."
+        )
+
+    try:
+        parsed = urlsplit(value)
+    except ValueError as exception:
+        raise ValueError("ELASTICSEARCH_URL is not a valid URL.") from exception
+    if parsed.scheme != "https":
+        raise ValueError("ELASTICSEARCH_URL must use HTTPS.")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("ELASTICSEARCH_URL must not contain user information.")
+    if parsed.query or parsed.fragment:
+        raise ValueError("ELASTICSEARCH_URL must not contain a query or fragment.")
+    if parsed.path not in ("", "/"):
+        raise ValueError("ELASTICSEARCH_URL must not contain a path.")
+
+    try:
+        port = parsed.port
+    except ValueError as exception:
+        raise ValueError("ELASTICSEARCH_URL contains an invalid port.") from exception
+    if port not in (None, 443):
+        raise ValueError("ELASTICSEARCH_URL port must be 443 when specified.")
+
+    hostname = parsed.hostname
+    expected_suffixes = tuple(
+        f".{region}{host_suffix}" for host_suffix in ELASTICSEARCH_HOST_SUFFIXES
+    )
+    if hostname is None or not hostname.endswith(expected_suffixes):
+        raise ValueError(
+            "ELASTICSEARCH_URL must use an AWS Elasticsearch service hostname "
+            "in the configured AWS region."
+        )
+
+    path = f"/{ELASTICSEARCH_INDEX}/_delete_by_query"
+    return urlunsplit(("https", hostname, path, "", ""))

--- a/src/trustymail_csv2mongo.py
+++ b/src/trustymail_csv2mongo.py
@@ -14,6 +14,9 @@ from mongo_db_from_config import db_from_config
 import requests
 from requests_aws4auth import AWS4Auth
 
+# cisagov Libraries
+from elasticsearch_config import get_elasticsearch_delete_url
+
 DB_CONFIG_FILE = "/run/secrets/scan_write_creds.yml"
 HOME_DIR = os.environ.get("CISA_HOME")
 INCLUDE_DATA_DIR = f"{HOME_DIR}/include"
@@ -26,13 +29,6 @@ UNIQUE_AGENCIES_FILE = f"{SHARED_DATA_DIR}/artifacts/unique-agencies.csv"
 CLEAN_CURRENT_FEDERAL_FILE = f"{SHARED_DATA_DIR}/artifacts/clean-current-federal.csv"
 
 TRUSTYMAIL_RESULTS_FILE = f"{SHARED_DATA_DIR}/artifacts/results/trustymail.csv"
-
-ES_REGION = "us-east-1"
-ES_URL = (
-    "https://search-dmarc-import-elasticsearch-"
-    f"ekc3pdnqzcuifgu4qssctvq4v4.{ES_REGION}.es.amazonaws.com"
-    "/dmarc_aggregate_reports"
-)
 
 
 class Domainagency:
@@ -271,13 +267,17 @@ def store_data(clean_federal, agency_dict, db_config_file):
 
     # Grab the AWS credentials, since we will need them to query
     # elasticsearch
-    aws_credentials = boto3.Session().get_credentials()
+    aws_session = boto3.Session()
+    aws_credentials = aws_session.get_credentials()
     if aws_credentials is not None:
+        es_region = aws_session.region_name
+        es_delete_url = get_elasticsearch_delete_url(es_region)
+
         # Construct the auth from the AWS credentials
         awsauth = AWS4Auth(
             aws_credentials.access_key,
             aws_credentials.secret_key,
-            ES_REGION,
+            es_region,
             "es",
             session_token=aws_credentials.token,
         )
@@ -290,7 +290,7 @@ def store_data(clean_federal, agency_dict, db_config_file):
         }
         # Now perform the query
         response = requests.post(
-            f"{ES_URL}/_delete_by_query",
+            es_delete_url,
             auth=awsauth,
             json=query,
             headers={"Content-Type": "application/json"},

--- a/tests/test_elasticsearch_config.py
+++ b/tests/test_elasticsearch_config.py
@@ -58,9 +58,7 @@ def test_invalid_elasticsearch_url_is_rejected(value):
 def test_elasticsearch_url_region_must_match_signing_region():
     """The endpoint and SigV4 signing regions must match."""
     with pytest.raises(ValueError, match="configured AWS region"):
-        get_elasticsearch_delete_url(
-            "us-west-2", {"ELASTICSEARCH_URL": VALID_URL}
-        )
+        get_elasticsearch_delete_url("us-west-2", {"ELASTICSEARCH_URL": VALID_URL})
 
 
 @pytest.mark.parametrize(

--- a/tests/test_elasticsearch_config.py
+++ b/tests/test_elasticsearch_config.py
@@ -1,0 +1,82 @@
+"""Tests for Elasticsearch configuration helpers."""
+
+# Standard Python Libraries
+from pathlib import Path
+import sys
+
+# Third-Party Libraries
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+# cisagov Libraries
+from elasticsearch_config import get_elasticsearch_delete_url  # noqa: E402
+
+VALID_URL = "https://search-example123.us-east-1.es.amazonaws.com"
+EXPECTED_DELETE_URL = f"{VALID_URL}/dmarc_aggregate_reports/_delete_by_query"
+CHINA_URL = "https://search-example.cn-north-1.es.amazonaws.com.cn"
+ES_REGION = "us-east-1"
+
+
+@pytest.mark.parametrize("region", [None, ""])
+def test_missing_aws_region_is_rejected(region):
+    """The signing region must be configured."""
+    with pytest.raises(RuntimeError, match="AWS region"):
+        get_elasticsearch_delete_url(region, {"ELASTICSEARCH_URL": VALID_URL})
+
+
+@pytest.mark.parametrize("value", [None, "", "   "])
+def test_missing_elasticsearch_url_is_rejected(value):
+    """The URL is required when the helper is called."""
+    environment = {} if value is None else {"ELASTICSEARCH_URL": value}
+
+    with pytest.raises(RuntimeError, match="ELASTICSEARCH_URL"):
+        get_elasticsearch_delete_url(ES_REGION, environment)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        VALID_URL.replace("https://", "http://"),
+        "https://example.com",
+        VALID_URL.replace("https://", "https://user@example.com@"),
+        f"{VALID_URL}/another_index",
+        f"{VALID_URL}?wait_for_completion=false",
+        f"{VALID_URL}#fragment",
+        f"{VALID_URL}.example.com",
+        f"{VALID_URL}:80",
+        f"{VALID_URL}:notaport",
+        "https://[invalid",
+    ],
+)
+def test_invalid_elasticsearch_url_is_rejected(value):
+    """Unsafe Elasticsearch URLs are rejected before signing."""
+    with pytest.raises(ValueError, match="ELASTICSEARCH_URL"):
+        get_elasticsearch_delete_url(ES_REGION, {"ELASTICSEARCH_URL": value})
+
+
+def test_elasticsearch_url_region_must_match_signing_region():
+    """The endpoint and SigV4 signing regions must match."""
+    with pytest.raises(ValueError, match="configured AWS region"):
+        get_elasticsearch_delete_url(
+            "us-west-2", {"ELASTICSEARCH_URL": VALID_URL}
+        )
+
+
+@pytest.mark.parametrize(
+    ("region", "value", "expected"),
+    [
+        (ES_REGION, f" {VALID_URL}/ ", EXPECTED_DELETE_URL),
+        (ES_REGION, f"{VALID_URL}:443", EXPECTED_DELETE_URL),
+        (
+            "cn-north-1",
+            CHINA_URL,
+            f"{CHINA_URL}/dmarc_aggregate_reports/_delete_by_query",
+        ),
+    ],
+)
+def test_elasticsearch_url_is_validated_and_normalized(region, value, expected):
+    """Valid base URLs produce a normalized delete-by-query URL."""
+    result = get_elasticsearch_delete_url(region, {"ELASTICSEARCH_URL": value})
+
+    assert result == expected


### PR DESCRIPTION
## 🗣 Description ##

- Read the Elasticsearch base endpoint from `ELASTICSEARCH_URL` instead of embedding a deployment-specific cluster ID.
- Validate and normalize the endpoint before attaching AWS SigV4 credentials, and use the Boto3 session region for both validation and signing.
- Add focused positive and negative tests plus environment-variable documentation.

## 💭 Motivation and context ##

The DMARC retention cleanup path currently embeds one deployment's Elasticsearch hostname and region in the application image. That prevents the image from being configured safely for another deployment.

The root cause is that the request target and signing region are module constants rather than deployment configuration. This change resolves the endpoint lazily only after AWS credentials are found, so the existing no-credentials skip behavior remains unchanged. It accepts only standard AWS-managed Elasticsearch/OpenSearch HTTPS endpoints in the session's region before any authorization headers are constructed.

Companion PR [cisagov/orchestrator#202](https://github.com/cisagov/orchestrator/pull/202) supplies the endpoint to the documented production runner and should be merged/deployed before releasing this saver change.

Resolves #100.

## 🧪 Testing ##

- `python -m pytest --runslow` — 20 passed.
- `pre-commit run --all-files` — every applicable hook passed, including Black, Flake8, mypy, Bandit, pip-audit, and Docker Compose validation.
- `python -m compileall -q src tests` — passed.
- `git diff --check` — passed.

The baseline reproduction confirmed that setting an endpoint environment variable did not affect the hardcoded request target. The new regression tests verify configured endpoints, normalization, missing configuration, region mismatch, and rejection of unsafe URL forms.

## Risk

Deployments with AWS credentials must provide `ELASTICSEARCH_URL`; the companion orchestrator PR covers the documented deployment. The current no-credentials path is preserved. Custom/proxied OpenSearch endpoints are intentionally rejected, and no dependency, telemetry, or external service was added.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

- [ ] The companion orchestrator configuration is merged or otherwise available before this saver version is deployed.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Create a release (necessary if and only if the version was bumped).
