### PR TITLE
Let Renovate handle dependencies that Dependabot cannot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,41 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  constraints: {
+    // Must be kept in sync with the major-minor version of Python
+    // being used in the base containers in the Dockerfile.
+    python: "==3.14",
+  },
+
+  customManagers: [
+    {
+      customType: "regex",
+      datasourceTemplate: "pypi",
+      managerFilePatterns: ["Dockerfile"],
+      matchStrings: [
+        "#\\s*renovate:\\s*datasource=pypi\\s+depName=(?<depName>\\S+)\\s*(ENV|ARG)?\\s*.+_VERSION=(?<currentValue>\\S+)",
+      ],
+    },
+    {
+      customType: "regex",
+      datasourceTemplate: "repology",
+      managerFilePatterns: ["Dockerfile"],
+      matchStrings: [
+        "#\\s*renovate:\\s*datasource=repology\\s+depName=(?<depName>\\S+)\\s*(ENV|ARG)?\\s*.+_VERSION=(?<currentValue>\\S+)",
+      ],
+    },
+    {
+      customType: "regex",
+      datasourceTemplate: "github-releases",
+      depNameTemplate: "cisagov/mongo-db-from-config",
+      managerFilePatterns: ["/^src/Pipfile$/"],
+      matchStrings: [
+        "cisagov/mongo-db-from-config/archive/(?<currentValue>\\S+).tar.gz",
+      ],
+      versioningTemplate: "semver-coerced", // handles the leading `v`
+    },
+  ],
+  dependencyDashboard: true,
+  enabledManagers: ["custom.regex"],
+  extends: ["config:recommended"],
+  labels: ["dependencies"],
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,11 @@ ENV CISA_HOME="/home/${CISA_USER}"
 ENV VIRTUAL_ENV="${CISA_HOME}/.venv"
 
 # Versions of the Python packages installed directly
+# renovate: datasource=pypi depName=pip
 ENV PYTHON_PIP_VERSION=26.1.2
+# renovate: datasource=pypi depName=pipenv
 ENV PYTHON_PIPENV_VERSION=2026.6.2
+# renovate: datasource=pypi depName=setuptools
 ENV PYTHON_SETUPTOOLS_VERSION=82.0.1
 
 ###
@@ -82,12 +85,17 @@ RUN addgroup --system --gid ${CISA_UID} ${CISA_GROUP} \
 #
 # We need redis so we can use redis-cli to communicate with redis.
 #
+# Note that the "alpine_3_23" strings below must be kept in sync with
+# the version of Alpine corresponding to the base images.
+#
 # Note that we use apk --no-cache to avoid writing to a local cache.
 # This results in a smaller final image, at the cost of slightly
 # longer install times.
 ###
-RUN apk --no-cache add \
-    redis=8.4.2-r0
+# renovate: datasource=repology depName=alpine_3_23/redis
+ENV REDIS_VERSION=8.4.2-r0
+ENV DEPS="redis=${REDIS_VERSION}"
+RUN apk --no-cache add $DEPS
 
 ###
 # Copy in the Python virtual environment created in compile-stage, symlink the


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a Renovate configuration and some Renovate annotations to allow Renovate to manage some dependencies that Dependabot cannot handle.

## 💭 Motivation and context ##

These dependencies were being updated manually before, so this is an improvement.

## 🧪 Testing ##

I verified that the Renovate config is valid and functions as expected by performing a dry run of Renovate locally.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.